### PR TITLE
Add simple storage module.

### DIFF
--- a/src/modules/storage.d.ts
+++ b/src/modules/storage.d.ts
@@ -1,0 +1,12 @@
+interface Store<T> {
+  value: T
+  set: (newValue: T) => void
+  close: () => void
+}
+interface Storage {
+  createStore: <T>(storeName: string, defaultValue: T) => Store<T>
+}
+interface Options {
+  writeDelay?: number
+}
+export default function (owner: string, options: Options = {}): Storage

--- a/src/modules/storage.d.ts
+++ b/src/modules/storage.d.ts
@@ -1,3 +1,5 @@
+import { Debugger } from "debug"
+
 interface Store<T> {
   value: T
   set: (newValue: T) => void
@@ -7,6 +9,8 @@ interface Storage {
   createStore: <T>(storeName: string, defaultValue: T) => Store<T>
 }
 interface Options {
+  log: Debugger
+  verbose?: boolean
   writeDelay?: number
 }
 export default function (owner: string, options: Options = {}): Storage

--- a/src/modules/storage.d.ts
+++ b/src/modules/storage.d.ts
@@ -2,7 +2,8 @@ import { Debugger } from "debug"
 
 interface Store<T> {
   value: T
-  set: (newValue: T) => void
+  get: <U>(path: [string | number]) => Store<U>
+  set: (newValue: T | ((T) => T)) => void
   close: () => void
 }
 interface Storage {

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 
 let stores = {}
 
-export default (pluginName, { writeDelay = 1000 } = {}) => ({
+export default (pluginName, { verbose = false, log, writeDelay = 10000 } = {}) => ({
   createStore: (root, defaultValue) => {
     const suffix = root ? `-${root}` : ''
     const filename = `data/${pluginName}${suffix}.json`
@@ -11,7 +11,10 @@ export default (pluginName, { writeDelay = 1000 } = {}) => ({
     }
     const value = (fs.existsSync(filename)) ?
       JSON.parse(fs.readFileSync(filename, "utf8")) : defaultValue
-    const writeFile = (value) => fs.writeFileSync(filename, JSON.stringify(value), "utf8")
+    const writeFile = (value) => {
+      fs.writeFileSync(filename, JSON.stringify(value), "utf8")
+      verbose && log("storage write")
+    }
     const store = {
       value: value,
     }
@@ -25,6 +28,7 @@ export default (pluginName, { writeDelay = 1000 } = {}) => ({
       }
     }
     store.set = (newValue) => {
+      verbose && log("storage set value")
       store.value = newValue
       throttleWrite()
     }
@@ -48,6 +52,7 @@ export default (pluginName, { writeDelay = 1000 } = {}) => ({
       fs.existsSync(filename) && fs.unlinkSync(filename)
     }
     stores[filename] = store
+    verbose && log("storage created")
     return store
   },
   _getCurrentStores: () => stores,

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -1,0 +1,54 @@
+import fs from 'fs'
+
+let stores = {}
+
+export default (pluginName, { writeDelay = 1000 } = {}) => ({
+  createStore: (root, defaultValue) => {
+    const suffix = root ? `-${root}` : ''
+    const filename = `data/${pluginName}${suffix}.json`
+    if (stores[filename]) {
+      return stores[filename]
+    }
+    const value = (fs.existsSync(filename)) ?
+      JSON.parse(fs.readFileSync(filename, "utf8")) : defaultValue
+    const writeFile = (value) => fs.writeFileSync(filename, JSON.stringify(value), "utf8")
+    const store = {
+      value: value,
+    }
+    store.pendingSave = false
+    const throttleWrite = () => {
+      if (!store.pendingSave) {
+        store.pendingSave = setTimeout(() => {
+          store.pendingSave = false
+          writeFile(store.value)
+        }, writeDelay)
+      }
+    }
+    store.set = (newValue) => {
+      store.value = newValue
+      throttleWrite()
+    }
+    store._flush = () => {
+      if (store.pendingSave) {
+        clearTimeout(store.pendingSave)
+        writeFile(store.value)
+        store.pendingSave = false
+      }
+    }
+    store.close = () => {
+      store._flush()
+      delete stores[filename]
+    }
+    store.delete = () => {
+      store.value = defaultValue
+      if (store.pendingSave) {
+        clearTimeout(store.pendingSave)
+        store.pendingSave = false
+      }
+      fs.existsSync(filename) && fs.unlinkSync(filename)
+    }
+    stores[filename] = store
+    return store
+  },
+  _getCurrentStores: () => stores,
+})

--- a/src/modules/storage.js
+++ b/src/modules/storage.js
@@ -1,14 +1,14 @@
 import fs from 'fs'
-import { isEmpty, modifyPath, path as rPath } from 'ramda'
+import { isEmpty, assocPath, path as rPath } from 'ramda'
 
 let stores = {}
 
 function setPath(newValue, path, value) {
-  let func = typeof newValue === 'function' ? newValue : () => newValue
+  newValue = typeof newValue === 'function' ? newValue(rPath(path, value)) : newValue
   if (isEmpty(path)) {
-    return func(value)
+    return newValue
   }
-  return modifyPath(path, func, value)
+  return assocPath(path, newValue, value)
 }
 
 function getPath(store, path) {

--- a/src/plugins/admin.js
+++ b/src/plugins/admin.js
@@ -2,7 +2,8 @@ import { omit } from "ramda";
 import commandParser from "../commandParser";
 import eventTypes from "../eventTypes";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const processMessage = async (message) => {
     const command = commandParser(message.text);
     if (command === null) {

--- a/src/plugins/almuerzo.js
+++ b/src/plugins/almuerzo.js
@@ -6,7 +6,8 @@ import { userToString } from "../slackUtils";
 
 const almuerzoFile = "data/almuerzo.json";
 
-export default (config, emitter, debug) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   let state = {
     messages: {},
   };

--- a/src/plugins/autobot.js
+++ b/src/plugins/autobot.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 /* el linter se queja y con razon, esto no es una buena idea */
-export default (config, emitter) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on("received:message", (message) => {
     if (!message.text.includes("code: ")) {
       return;

--- a/src/plugins/aye.js
+++ b/src/plugins/aye.js
@@ -1,6 +1,7 @@
 import commandParser from "../commandParser";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on("received:message", (message) => {
     const command = commandParser(message.text);
     log(command);

--- a/src/plugins/dance.js
+++ b/src/plugins/dance.js
@@ -3,7 +3,8 @@ import eventTypes from "../eventTypes";
 import frames from "./animations/flip.json";
 import waves from "./animations/waves.json";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const animate = (ts, channel, [frame, ...tail]) => {
     emitter.emit(
       eventTypes.OUT.webPost,

--- a/src/plugins/define.js
+++ b/src/plugins/define.js
@@ -2,7 +2,8 @@ import { create } from "apisauce";
 import { take, forEach, propOr, compose, map, ifElse, lt, length } from "ramda";
 import commandParser from "../commandParser";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   // define the api
   const api = create({
     baseURL: "http://api.urbandictionary.com/v0/define",

--- a/src/plugins/dolar.js
+++ b/src/plugins/dolar.js
@@ -1,7 +1,8 @@
 import { create } from "apisauce";
 import commandParser from "../commandParser";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const api = create({
     baseURL: "https://mercados.ambito.com",
     headers: { Accept: "application/json" },

--- a/src/plugins/echo.js
+++ b/src/plugins/echo.js
@@ -1,4 +1,5 @@
-export default (config, emitter) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on("received:message", (message) => {
     emitter.emit("send:message", message.text, message.channel);
   });

--- a/src/plugins/fifando.js
+++ b/src/plugins/fifando.js
@@ -17,7 +17,8 @@ function popMatch(text) {
 const showMatches = (text) =>
   queue.map((match, index) => `${index} <@${match.join("> - <@")}>`).join("\n");
 
-export default (config, emitter) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter }) => {
   emitter.on("received:message", (message) => {
     const command = commandParser(message.text);
     if (command === null) {

--- a/src/plugins/jpsandiego.js
+++ b/src/plugins/jpsandiego.js
@@ -3,7 +3,8 @@ import eventTypes from "../eventTypes";
 
 let where = "";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on(eventTypes.IN.receivedMessage, (message) => {
     log(message);
     const command = commandParser(message.text);

--- a/src/plugins/lobo.js
+++ b/src/plugins/lobo.js
@@ -6,7 +6,8 @@ const forwardTemplate = (channel, user, text) =>({
 > ${text.replace(/\n/g, "\n> ")}`
 });
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on(eventTypes.IN.receivedOtherMessage, (message) => {
     if (!keys(config.channels).includes(message.channel)) {
       return;

--- a/src/plugins/manija.js
+++ b/src/plugins/manija.js
@@ -4,7 +4,8 @@ import table from "text-table";
 
 import commandParser from "./../commandParser";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const doc = new GoogleSpreadsheet(
     "1fW46QXKO4XDd-L8hoYFR30AzzVVDe4mL1xhZthbDgtI"
   );

--- a/src/plugins/markov.js
+++ b/src/plugins/markov.js
@@ -16,7 +16,8 @@ const debouncedSave = (data) => {
   }
 };
 
-export default (config, emitter, debug) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const chain = new MarkovChain("");
 
   if (fs.existsSync(chainFile)) {

--- a/src/plugins/plugin.d.ts
+++ b/src/plugins/plugin.d.ts
@@ -1,0 +1,13 @@
+import { Storage } from "../modules/storage"
+
+// These are any until they can be typed
+interface PluginOptions {
+  config: any
+  emitter: any
+  log: any
+  storage: Storage
+}
+
+interface TaperbotPlugin {
+  (options: PluginOptions): void
+}

--- a/src/plugins/proximoferiado.js
+++ b/src/plugins/proximoferiado.js
@@ -27,7 +27,8 @@ const weekDaysLocale = [
 
 import commandParser from "../commandParser";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on("received:message", (message) => {
     const command = commandParser(message.text);
     if (command === null || command.command !== "proximoferiado") {

--- a/src/plugins/rati.js
+++ b/src/plugins/rati.js
@@ -1,4 +1,5 @@
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   emitter.on("reaction:added", (payload) => {
     if (
       payload.item.type === "message" &&

--- a/src/plugins/slackbot-reactions.js
+++ b/src/plugins/slackbot-reactions.js
@@ -46,7 +46,8 @@ function reactTo(allReactions, words, emitter, ts, channel) {
   });
 }
 
-export default (config, emitter, debug) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const deleteReaction = config.deleteReaction;
   let allReactions = {};
   if (fs.existsSync(reactionsFile)) {
@@ -139,7 +140,7 @@ export default (config, emitter, debug) => {
             ts: payload.item.ts,
           },
           (error) => {
-            debug(error);
+            log(error);
           }
         );
       } else {
@@ -154,7 +155,7 @@ export default (config, emitter, debug) => {
           },
           (error, response) => {
             if (error) {
-              debug(error);
+              log(error);
             } else if (response.messages.length > 0) {
               response.messages[0].reactions.forEach((r) => {
                 if (r.users.indexOf(config.userId) >= 0) {

--- a/src/plugins/tiltalks.js
+++ b/src/plugins/tiltalks.js
@@ -1,7 +1,8 @@
 import { create } from "apisauce";
 import commandParser from "../commandParser";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const query = {
     query: `{
       repository(owner: "${config.org}", name: "${config.repo}") {

--- a/src/plugins/troll.js
+++ b/src/plugins/troll.js
@@ -1,7 +1,8 @@
 import commandParser from "../commandParser";
 import eventTypes from "../eventTypes";
 
-export default (config, emitter, debug) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const lockedChannels = new Set();
   emitter.on(eventTypes.IN.receivedMessage, (message) => {
     const command = commandParser(message.text);
@@ -36,7 +37,7 @@ export default (config, emitter, debug) => {
       },
       (err) => {
         if (err) {
-          debug(err);
+          log(err);
         }
       }
     );

--- a/src/plugins/utils.js
+++ b/src/plugins/utils.js
@@ -1,7 +1,8 @@
 import commandParser from "../commandParser";
 import { getChannels, getGroups, getUsers } from "../slackUtils";
 
-export default (config, emitter, log) => {
+/** @type { import("./plugin").TaperbotPlugin } */
+export default ({ config, emitter, log }) => {
   const processMessage = async (message) => {
     const command = commandParser(message.text);
     if (command === null) {

--- a/src/run.js
+++ b/src/run.js
@@ -22,12 +22,13 @@ const initPlugins = (config, emitter) => {
       const pluginConfig = config.plugins[pluginName];
       return [pluginName, require(`${pluginsFolder}${pluginName}`).default, pluginConfig];
     }).concat([["admin", adminPlugin, config]]).forEach( ([pluginName, plugin, config]) => {
-        plugin({
-          config,
-          emitter,
-          debug: createDebug(`taperbot:${pluginName}`),
-          storage: createStorage(pluginName),
-        })
+      const log = createDebug(`taperbot:${pluginName}`)
+      plugin({
+        config,
+        emitter,
+        log,
+        storage: createStorage(pluginName, { log }),
+      })
     });
 };
 

--- a/src/run.js
+++ b/src/run.js
@@ -70,7 +70,6 @@ app.event("reaction_removed", async ({ event, logger }) => {
   }
 });
 
-initPlugins(config, emitter);
 
 const startServer = async () => {
   await app.start(process.env.PORT || 3000);
@@ -96,6 +95,7 @@ const startServer = async () => {
   //     reply_to: message.id,
   //   });
   // });
+  initPlugins(config, emitter);
 };
 
 const sendMessage = (channel, content, id = getNextId()) => {

--- a/src/slackWeb.js
+++ b/src/slackWeb.js
@@ -24,5 +24,6 @@ const makeWebRequest = async (app, token, log, method, args, callback) => {
     callback(null, result);
   } catch (error) {
     log(error);
+    callback(error, null);
   }
 };

--- a/test/commandParser.js
+++ b/test/commandParser.js
@@ -21,7 +21,6 @@ describe("Test commandParser", function () {
     expect(result).to.be.equal(null);
 
     result = commandParser("<@U3FTH76RZ> saraza /testCommand asd asd");
-    console.log(result);
     expect(result).to.be.equal(null);
 
     done();

--- a/test/ratiTest.js
+++ b/test/ratiTest.js
@@ -36,7 +36,7 @@ describe("Test rati plugin", function () {
 
     emitter.on("send:message", spy);
 
-    rati(config, emitter, log);
+    rati({ config, emitter, log });
     emitter.emit(
       "reaction:added",
       getReactionPayload(new Date(2017, 3, 2), new Date(2017, 3, 3))
@@ -51,7 +51,7 @@ describe("Test rati plugin", function () {
 
     emitter.on("send:message", spy);
 
-    rati(config, emitter, log);
+    rati({ config, emitter, log });
     emitter.emit(
       "reaction:added",
       getReactionPayload(new Date(2017, 3, 2), new Date(2017, 3, 2))
@@ -66,7 +66,7 @@ describe("Test rati plugin", function () {
 
     emitter.on("send:message", spy);
 
-    rati(config, emitter, log);
+    rati({ config, emitter, log });
     emitter.emit(
       "reaction:added",
       getReactionPayload(new Date(2017, 3, 2), new Date(2017, 3, 3))

--- a/test/storageTests.js
+++ b/test/storageTests.js
@@ -51,7 +51,7 @@ describe("Test storage", function () {
     store = storage.createStore("substore", {})
     substore = store.get(['a', 'b', 0])
     expect(substore.value).to.eql({ c: 'chau' })
-    substore.get(['c']).set((v) => `hola-${v}`)
+    substore.get(['c']).set((value) => `hola-${value}`)
     expect(substore.value).to.eql({ c: 'hola-chau' })
     substore = substore.get(["d"])
     substore.set("nuevo")

--- a/test/storageTests.js
+++ b/test/storageTests.js
@@ -1,0 +1,40 @@
+/* eslint-env mocha */
+import chai from "chai"
+import fs from 'fs'
+
+import createStorage from "../src/modules/storage"
+
+const expect = chai.expect;
+
+describe("Test storage", function () {
+  let storage = createStorage("tests")
+  fs.existsSync('data/tests.json') && fs.unlinkSync('data/tests.json')
+  fs.existsSync('data/tests-other.json') && fs.unlinkSync('data/tests-other.json')
+  it("default store", function () {
+    const store = storage.createStore() // default
+    expect(store.value).to.equal(undefined)
+    expect(store).to.equal(storage._getCurrentStores()['data/tests.json'])
+    store.close()
+    expect(storage._getCurrentStores()['data/tests.json']).to.equal(undefined)
+  })
+  it("default store with value", function () {
+    let store = storage.createStore(false, "defaultValue")
+    expect(store.value).to.equal("defaultValue")
+    store.set("nonDefaultValue")
+    store.close()
+    store = storage.createStore(false, "anotherDefaultValue")
+    expect(store.value).to.equal("nonDefaultValue")
+    store.delete()
+  })
+  it("other store with value", function () {
+    let store = storage.createStore("other", "defaultValue")
+    expect(store.value).to.equal("defaultValue")
+    store.set("nonDefaultValue")
+    store._flush() // so file is saved
+    expect(JSON.stringify(store.value)).to.equal(fs.readFileSync('data/tests-other.json', "utf8"))
+    store.set("anotherValue")
+    store = storage.createStore("other", "anotherDefaultValue")
+    expect(store.value).to.equal("anotherValue")
+    store.delete()
+  })
+})


### PR DESCRIPTION
Interfaz de Storage simple para en algún momento migrar a algo más complejo sin tocar tanto los plugins.
Patea solo la escritura al archivo unos diez segundos para evitar escribir cada cambio al disco.
Uso:
```
import createStorage from 'modules/storage'

const storage = createStorage("almuerzo", { log: logger })
const store = storage.createStore(nombre, defaultValue)
store.value // el valor actual
store.set(newValue) // para actualizar el valor
let valor = store.get(["path", "a", "valor"]) // para obtener un sub store a una clave en particular
valor.value // el valor de la clave
valor.set(newValue) // cambia el valor en la clave
valor.get(["mas", "claves"]) // entra más en profundidad
store.close() // si no se va a usar más
```

Las cosas que arrancan con `_` están porque hacían falta en los tests pero la idea sería que no se usen.
Revisar commit por commit.